### PR TITLE
#30 Fixed pytest error for Windows

### DIFF
--- a/tests/test_connection_pooling.py
+++ b/tests/test_connection_pooling.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import unittest
 from typing import List
@@ -15,6 +16,7 @@ class TestBaseLogger(unittest.TestCase):
         )
 
     def tearDown(self) -> None:
+        logging.shutdown()
         os.remove("test_debug.log")
 
     def test_requests_keep_alive(self) -> None:


### PR DESCRIPTION
Solution to issue #30. Since `pytest` was still running for the `tests/test_connection_pooling.py` test, `os.remove` wasn't able to delete the file. Solved it by shutting down logging with `logging.shutdown()`